### PR TITLE
Add handling for 'error' object returned from the API

### DIFF
--- a/force-app/main/default/classes/BadgeData.cls
+++ b/force-app/main/default/classes/BadgeData.cls
@@ -5,6 +5,8 @@
 * A class to deserialize Trailhead Badge data from the API into.
 */
 public class BadgeData {
+    public String error { get; set; }
+
     @AuraEnabled
     public List<value> value { get; set; }
 

--- a/force-app/main/default/classes/CertificationData.cls
+++ b/force-app/main/default/classes/CertificationData.cls
@@ -5,6 +5,8 @@
 * A class to deserialize Trailhead Certification data from the API into.
 */
 public class CertificationData {
+    public String error { get; set; }
+    
     @AuraEnabled
     public List<certificationsList> certificationsList { get; set; }
 

--- a/force-app/main/default/classes/GetTrailblazerInfoAsync.cls
+++ b/force-app/main/default/classes/GetTrailblazerInfoAsync.cls
@@ -9,6 +9,11 @@ public class GetTrailblazerInfoAsync implements Queueable, Database.AllowsCallou
     public static final String TRAILHEAD_ME_USERID = 'https://trailblazer.me/id?cmty=trailhead&uid=';
     public static final String GO_TRAILHEAD_API = 'https://go-trailhead-leaderboard-api.herokuapp.com/trailblazer/';
     public static final String JOB_NAME = 'Populate Trailblazers from GetTrailblazerInfoAsync';
+    public static final String PROFILE_PATH = '/profile';
+    public static final String SUPERBADGES_PATH = '/badges/superbadge';
+    public static final String CERTIFICATIONS_PATH = '/certifications';
+    public static final String HEROKU_ERROR = 'Application error';
+    public static final String SUCCESS = 'success';
 
     private Integer jobCount = 0;
     private List<Trailblazer__c> trailblazers;
@@ -24,12 +29,12 @@ public class GetTrailblazerInfoAsync implements Queueable, Database.AllowsCallou
         }
 
         Trailblazer__c trailblazer = trailblazers[0];
-        populateTrailblazerProfileData(trailblazer, getProfileData(trailblazer));
-        populateTrailblazerProfileCountsData(trailblazer, getProfileCountData(trailblazer));
-        populateTrailblazerSuperbadgeData(trailblazer, getSuperbadgeData(trailblazer));
-        populateTrailblazerCertificationData(trailblazer, getCertificationData(trailblazer));
+        getProfileCountsData(trailblazer, buildCalloutURL(trailblazer, ''));
+        getProfileData(trailblazer, buildCalloutURL(trailblazer, PROFILE_PATH));
+        getSuperbadgeData(trailblazer, buildCalloutURL(trailblazer, SUPERBADGES_PATH));
+        getCertificationData(trailblazer, buildCalloutURL(trailblazer, CERTIFICATIONS_PATH));
 
-        if (!String.isBlank(trailblazer.Profile_Handle__c) && !String.isBlank(trailblazer.Name)) {
+        if (!String.isBlank(trailblazer.Profile_Handle__c)) {
             upsert trailblazer Profile_Handle__c;
         }
 
@@ -48,19 +53,22 @@ public class GetTrailblazerInfoAsync implements Queueable, Database.AllowsCallou
     }
 
     /**
-     * Calls out to the /profile/ endpoint to get a JSON response.
-     *
+     * Bulids the callout endpoint before calling doCallout() to get a JSON response.
+     * 
+     * @see doCallout()
+     * 
      * @param trailblazer, the Trailblazer__c record to populate with response data.
+     * @param path, the URL path to append to the end of the default callout URL i.e. '/certifications'.
      *
      * @return res.getBody(), the JSON response body returned from the endpoint.
      */
-    public static String getProfileData(Trailblazer__c trailblazer) {
+    public static String buildCalloutURL(Trailblazer__c trailblazer, String path) {
         String calloutURL = '';
 
         if (!String.isBlank(trailblazer.Profile_Handle__c)) {
-            calloutURL = GO_TRAILHEAD_API + trailblazer.Profile_Handle__c + '/profile';
+            calloutURL = GO_TRAILHEAD_API + trailblazer.Profile_Handle__c + (!String.isBlank(path) ? path : '');
         } else {
-            calloutURL = GO_TRAILHEAD_API + trailblazer.Profile_Id__c + '/profile';
+            calloutURL = GO_TRAILHEAD_API + trailblazer.Profile_Id__c + (!String.isBlank(path) ? path : '');
         }
 
         return doCallout(calloutURL);
@@ -70,16 +78,21 @@ public class GetTrailblazerInfoAsync implements Queueable, Database.AllowsCallou
      * Writes data from the /profile/ endpoint to the Trailblazer__c record.
      *
      * @param trailblazer, a Trailblazer__c record to write to.
+     * 
      * @param resBody, the response body JSON to deserialize and write to the Trailblazer__c record.
      */
-    public static void populateTrailblazerProfileData(Trailblazer__c trailblazer, String resBody) {
-        if (resBody.contains('application-error') || String.isBlank(resBody)) {
-            return;
+    public static String getProfileData(Trailblazer__c trailblazer, String resBody) {
+        if (resBody.contains(HEROKU_ERROR) || String.isBlank(resBody)) {
+            return buildErrorAsJSON('Application Error, please try again. API may be down.');
         }
 
         ProfileData data = (ProfileData) JSON.deserialize(resBody.replaceAll('__c', ''), ProfileData.class);
+        
+        if (!String.isBlank(data.error)) {
+            return data.error;
+        }
 
-        if (String.isBlank(data.error) && data.profileUser != null) {
+        if (data.profileUser != null) {
             trailblazer.Profile_Id__c = data.profileUser.Id;
             trailblazer.Name = data.profileUser.FirstName + ' ' + data.profileUser.LastName;
             trailblazer.Profile_Photo__c = data.profilePhotoUrl;
@@ -94,42 +107,29 @@ public class GetTrailblazerInfoAsync implements Queueable, Database.AllowsCallou
                 trailblazer.Profile_Link__c = TRAILHEAD_ME_USERID + data.profileUser.Id;
             }
         }
-    }
-
-    /**
-     * Calls out to the /trailblazer/ endpoint to get a JSON response.
-     *
-     * @param trailblazer, the Trailblazer__c record to populate with response data.
-     *
-     * @return res.getBody(), the JSON response body returned from the endpoint.
-     */
-    public static String getProfileCountData(Trailblazer__c trailblazer) {
-        String calloutURL = '';
-
-        if (!String.isBlank(trailblazer.Profile_Handle__c)) {
-            calloutURL = GO_TRAILHEAD_API + trailblazer.Profile_Handle__c;
-        } else {
-            calloutURL = GO_TRAILHEAD_API + trailblazer.Profile_Id__c;
-        }
-
-        return doCallout(calloutURL);
+        
+        return SUCCESS;
     }
 
     /**
      * Writes data from the /trailblazer/ endpoint to the Trailblazer__c record.
      *
      * @param trailblazer, a Trailblazer__c record to write to.
+     * 
      * @param resBody, the response body JSON to deserialize and write to the Trailblazer__c record.
      */
-    public static void populateTrailblazerProfileCountsData(Trailblazer__c trailblazer, String resBody) {
-        if (resBody.contains('application-error') || String.isBlank(resBody)) {
-            return;
+    public static String getProfileCountsData(Trailblazer__c trailblazer, String resBody) {
+        if (resBody.contains(HEROKU_ERROR) || String.isBlank(resBody)) {
+            return buildErrorAsJSON('Application Error, please try again. API may be down.');
         }
 
         ProfileCountData data = (ProfileCountData) JSON.deserialize(resBody.replaceAll('__c', ''), ProfileCountData.class);
 
-        if (String.isBlank(data.error)
-            && data.value != null && !data.value.isEmpty() 
+        if (!String.isBlank(data.error)) {
+            return data.error;
+        }
+        
+        if (data.value != null && !data.value.isEmpty() 
             && data.value[0].ProfileCounts != null 
             && !data.value[0].ProfileCounts.isEmpty()
         ) {
@@ -139,42 +139,29 @@ public class GetTrailblazerInfoAsync implements Queueable, Database.AllowsCallou
             trailblazer.Rank__c = data.value[0].ProfileCounts[0].RankLabel.capitalize();
             trailblazer.Rank_Badge_Link__c = data.value[0].ProfileCounts[0].RankImageUrl;
         }
-    }
-
-    /**
-     * Calls out to the /trailblazer/ endpoint to get a JSON response.
-     *
-     * @param trailblazer, the Trailblazer__c record to populate with response data.
-     *
-     * @return res.getBody(), the JSON response body returned from the endpoint.
-     */
-    public static String getSuperbadgeData(Trailblazer__c trailblazer) {
-        String calloutURL = '';
-
-        if (!String.isBlank(trailblazer.Profile_Handle__c)) {
-            calloutURL = GO_TRAILHEAD_API + trailblazer.Profile_Handle__c + '/badges/superbadge';
-        } else {
-            calloutURL = GO_TRAILHEAD_API + trailblazer.Profile_Id__c + '/badges/superbadge';
-        }
-
-        return doCallout(calloutURL);
+        
+        return SUCCESS;
     }
 
     /**
      * Writes data from the /trailblazer/ endpoint to the Trailblazer__c record.
      *
      * @param trailblazer, a Trailblazer__c record to write to.
+     * 
      * @param resBody, the response body JSON to deserialize and write to the Trailblazer__c record.
      */
-    public static void populateTrailblazerSuperbadgeData(Trailblazer__c trailblazer, String resBody) {
-        if (resBody.contains('application-error') || String.isBlank(resBody)) {
-            return;
+    public static String getSuperbadgeData(Trailblazer__c trailblazer, String resBody) {
+        if (resBody.contains(HEROKU_ERROR) || String.isBlank(resBody)) {
+            return buildErrorAsJSON('Application Error, please try again. API may be down.');
         }
 
         BadgeData data = (BadgeData) JSON.deserialize(resBody.replaceAll('__c', ''), BadgeData.class);
 
-        if (String.isBlank(data.error) 
-            && data.value != null 
+        if (!String.isBlank(data.error)) {
+            return data.error;
+        }
+
+        if (data.value != null 
             && !data.value.isEmpty() 
             && data.value[0].EarnedAwards != null 
             && !data.value[0].EarnedAwards.isEmpty()
@@ -187,53 +174,43 @@ public class GetTrailblazerInfoAsync implements Queueable, Database.AllowsCallou
 
             trailblazer.Superbadges__c = count;
         }
-    }
 
-    /**
-     * Calls out to the /trailblazer/ endpoint to get a JSON response.
-     *
-     * @param trailblazer, the Trailblazer__c record to populate with response data.
-     *
-     * @return res.getBody(), the JSON response body returned from the endpoint.
-     */
-    public static String getCertificationData(Trailblazer__c trailblazer) {
-        String calloutURL = '';
-
-        if (!String.isBlank(trailblazer.Profile_Handle__c)) {
-            calloutURL = GO_TRAILHEAD_API + trailblazer.Profile_Handle__c + '/certifications';
-        } else {
-            calloutURL = GO_TRAILHEAD_API + trailblazer.Profile_Id__c + '/certifications';
-        }
-
-        return doCallout(calloutURL);
+        return SUCCESS;
     }
 
     /**
      * Writes data from the /trailblazer/ endpoint to the Trailblazer__c record.
      *
      * @param trailblazer, a Trailblazer__c record to write to.
+     * 
      * @param resBody, the response body JSON to deserialize and write to the Trailblazer__c record.
      */
-    public static void populateTrailblazerCertificationData(Trailblazer__c trailblazer, String resBody) {
-        if (resBody.contains('application-error') || String.isBlank(resBody)) {
-            return;
+    public static String getCertificationData(Trailblazer__c trailblazer, String resBody) {
+        if (resBody.contains(HEROKU_ERROR) || String.isBlank(resBody)) {
+            return buildErrorAsJSON('Application Error, please try again. API may be down.');
         }
 
         CertificationData data = (CertificationData) JSON.deserialize(resBody.replaceAll('__c', ''), CertificationData.class);
 
-        if (String.isBlank(data.error)
-            && data != null 
+        if (!String.isBlank(data.error)) {
+            return data.error;
+        }
+
+        if (data != null 
             && data.certificationsList != null 
             && !data.certificationsList.isEmpty()
         ) {
             trailblazer.Certifications__c = data.certificationsList.size();
         }
+
+        return SUCCESS;
     }
 
     /**
      * Creates a callout using the supplied URL.
      *
      * @param calloutURL, the URL to do a callout to.
+     * 
      * @return res.getBody() the body of the callout response.
      */
     public static String doCallout(String calloutURL) {
@@ -245,5 +222,24 @@ public class GetTrailblazerInfoAsync implements Queueable, Database.AllowsCallou
         HttpResponse res = h.send(req);
 
         return res.getBody();
+    }
+
+    /**
+     * Returns a JSON Error object from the provided message String.
+     * 
+     * @param message, the String to output as the Error message. 
+     * 
+     * @return a serialized GetTrailblazerInfoAsync.Error object.
+     */
+    private static String buildErrorAsJSON(String message) {
+        return JSON.serialize(new Error(message));
+    }
+
+    class Error {
+        public String error { get; set; }
+
+        public Error(String message) {
+            this.error = message;
+        }
     }
 }

--- a/force-app/main/default/classes/GetTrailblazerInfoAsync.cls
+++ b/force-app/main/default/classes/GetTrailblazerInfoAsync.cls
@@ -24,17 +24,13 @@ public class GetTrailblazerInfoAsync implements Queueable, Database.AllowsCallou
         }
 
         Trailblazer__c trailblazer = trailblazers[0];
+        populateTrailblazerProfileData(trailblazer, getProfileData(trailblazer));
+        populateTrailblazerProfileCountsData(trailblazer, getProfileCountData(trailblazer));
+        populateTrailblazerSuperbadgeData(trailblazer, getSuperbadgeData(trailblazer));
+        populateTrailblazerCertificationData(trailblazer, getCertificationData(trailblazer));
 
-        Trailblazer__c newBlazer = new Trailblazer__c();
-        populateTrailblazerProfileData(newBlazer, getProfileData(trailblazer));
-        populateTrailblazerProfileCountsData(newBlazer, getProfileCountData(trailblazer));
-        populateTrailblazerSuperbadgeData(newBlazer, getSuperbadgeData(trailblazer));
-        populateTrailblazerCertificationData(newBlazer, getCertificationData(trailblazer));
-
-        if (!String.isBlank(newBlazer.Profile_Handle__c)
-            && !String.isBlank(newBlazer.Name)
-        ) {
-            upsert newBlazer Profile_Handle__c;
+        if (!String.isBlank(trailblazer.Profile_Handle__c) && !String.isBlank(trailblazer.Name)) {
+            upsert trailblazer Profile_Handle__c;
         }
 
         trailblazers.remove(0);
@@ -83,7 +79,7 @@ public class GetTrailblazerInfoAsync implements Queueable, Database.AllowsCallou
 
         ProfileData data = (ProfileData) JSON.deserialize(resBody.replaceAll('__c', ''), ProfileData.class);
 
-        if (data.profileUser != null) {
+        if (String.isBlank(data.error) && data.profileUser != null) {
             trailblazer.Profile_Id__c = data.profileUser.Id;
             trailblazer.Name = data.profileUser.FirstName + ' ' + data.profileUser.LastName;
             trailblazer.Profile_Photo__c = data.profilePhotoUrl;
@@ -132,7 +128,11 @@ public class GetTrailblazerInfoAsync implements Queueable, Database.AllowsCallou
 
         ProfileCountData data = (ProfileCountData) JSON.deserialize(resBody.replaceAll('__c', ''), ProfileCountData.class);
 
-        if (data.value != null && !data.value.isEmpty() && data.value[0].ProfileCounts != null && !data.value[0].ProfileCounts.isEmpty()) {
+        if (String.isBlank(data.error)
+            && data.value != null && !data.value.isEmpty() 
+            && data.value[0].ProfileCounts != null 
+            && !data.value[0].ProfileCounts.isEmpty()
+        ) {
             trailblazer.Points__c = data.value[0].ProfileCounts[0].EarnedPointTotal;
             trailblazer.Badges__c = data.value[0].ProfileCounts[0].EarnedBadgeTotal;
             trailblazer.Trails__c = data.value[0].ProfileCounts[0].CompletedTrailTotal;
@@ -173,7 +173,12 @@ public class GetTrailblazerInfoAsync implements Queueable, Database.AllowsCallou
 
         BadgeData data = (BadgeData) JSON.deserialize(resBody.replaceAll('__c', ''), BadgeData.class);
 
-        if (data.value != null && !data.value.isEmpty() && data.value[0].EarnedAwards != null && !data.value[0].EarnedAwards.isEmpty()) {
+        if (String.isBlank(data.error) 
+            && data.value != null 
+            && !data.value.isEmpty() 
+            && data.value[0].EarnedAwards != null 
+            && !data.value[0].EarnedAwards.isEmpty()
+        ) {
             Integer count = 0;
 
             for (BadgeData.EarnedAwards award : data.value[0].EarnedAwards) {
@@ -181,8 +186,6 @@ public class GetTrailblazerInfoAsync implements Queueable, Database.AllowsCallou
             }
 
             trailblazer.Superbadges__c = count;
-        } else {
-            trailblazer.Superbadges__c = 0;
         }
     }
 
@@ -218,10 +221,12 @@ public class GetTrailblazerInfoAsync implements Queueable, Database.AllowsCallou
 
         CertificationData data = (CertificationData) JSON.deserialize(resBody.replaceAll('__c', ''), CertificationData.class);
 
-        if (data != null && data.certificationsList != null && !data.certificationsList.isEmpty()) {
+        if (String.isBlank(data.error)
+            && data != null 
+            && data.certificationsList != null 
+            && !data.certificationsList.isEmpty()
+        ) {
             trailblazer.Certifications__c = data.certificationsList.size();
-        } else {
-            trailblazer.Certifications__c = 0;
         }
     }
 

--- a/force-app/main/default/classes/GetTrailblazerInfoAsyncTest.cls
+++ b/force-app/main/default/classes/GetTrailblazerInfoAsyncTest.cls
@@ -110,4 +110,66 @@ private class GetTrailblazerInfoAsyncTest {
         System.assertEquals(6, assertTrailblazers[0].Trails__c,
             'Trails__c should have been upserted to 6');
     }
+
+    @IsTest
+    static void testSuperbadgeDataError() {
+        // Arrange 
+        TrailheadCalloutMock mock = new TrailheadCalloutMock();
+        HttpResponse res = new HttpResponse();
+        res.setHeader('Content-Type', 'application/json');
+        res.setHeader('Location', 'trailheadURL.com');
+        res.setStatusCode(200);
+        res.setBody(TrailheadCalloutMock.getUnsuccessfulResponseData());
+        mock.addResponse(res);
+
+        Test.setMock(HttpCalloutMock.class, mock);
+
+        Trailblazer__c testTrailblazer = new List<Trailblazer__c>([
+            SELECT Profile_Handle__c, Profile_Id__c 
+            FROM Trailblazer__c
+        ])[0];
+
+        testTrailblazer.Superbadges__c = 3;
+        update testTrailblazer; // Set existing Trailblazer superbadges to 3. 
+
+        // Act
+        Test.startTest();
+        GetTrailblazerInfoAsync.populateTrailblazerSuperbadgeData(testTrailblazer, GetTrailblazerInfoAsync.getSuperbadgeData(testTrailblazer));
+        Test.stopTest();
+
+        // Assert
+        Trailblazer__c assertTrailblazer = [SELECT Superbadges__c FROM Trailblazer__c WHERE Id = :testTrailblazer.Id];
+        System.assertEquals(3, assertTrailblazer.Superbadges__c, 'Superbadges should not have been updated from a failed server callout.');
+    }
+
+    @IsTest
+    static void testCertificationDataError() {
+        // Arrange 
+        TrailheadCalloutMock mock = new TrailheadCalloutMock();
+        HttpResponse res = new HttpResponse();
+        res.setHeader('Content-Type', 'application/json');
+        res.setHeader('Location', 'trailheadURL.com');
+        res.setStatusCode(200);
+        res.setBody(TrailheadCalloutMock.getUnsuccessfulResponseData());
+        mock.addResponse(res);
+
+        Test.setMock(HttpCalloutMock.class, mock);
+
+        Trailblazer__c testTrailblazer = new List<Trailblazer__c>([
+            SELECT Profile_Handle__c, Profile_Id__c 
+            FROM Trailblazer__c
+        ])[0];
+
+        testTrailblazer.Certifications__c = 5;
+        update testTrailblazer; // Set existing Trailblazer certifications to 5. 
+
+        // Act
+        Test.startTest();
+        GetTrailblazerInfoAsync.populateTrailblazerCertificationData(testTrailblazer, GetTrailblazerInfoAsync.getCertificationData(testTrailblazer));
+        Test.stopTest();
+
+        // Assert
+        Trailblazer__c assertTrailblazer = [SELECT Certifications__c FROM Trailblazer__c WHERE Id = :testTrailblazer.Id];
+        System.assertEquals(5, assertTrailblazer.Certifications__c, 'Certifications should not have been updated from a failed server callout.');
+    }
 }

--- a/force-app/main/default/classes/GetTrailblazerInfoAsyncTest.cls
+++ b/force-app/main/default/classes/GetTrailblazerInfoAsyncTest.cls
@@ -2,7 +2,7 @@
 * @author meruff
 * @date 5/29/20
 *
-* Unit Tests for GetTrailblazerInfoAsyncTest
+* Unit Tests for GetTrailblazerInfoAsync.cls
 */
 @IsTest
 private class GetTrailblazerInfoAsyncTest {
@@ -15,6 +15,9 @@ private class GetTrailblazerInfoAsyncTest {
     }
 
     @IsTest
+    /**
+     * Tests successful Trailblazer__c callout and population.
+     */
     static void testGetTrailblazerInfo() {
         // Arrange
         TrailheadCalloutMock mock = new TrailheadCalloutMock();
@@ -61,6 +64,9 @@ private class GetTrailblazerInfoAsyncTest {
     }
 
     @IsTest
+    /**
+     * Tests successful callout and population without a custom Trailhead handle. Uses Trailhead User Id instead.
+     */
     static void testGetTrailblazerInfoNoHandle() {
         // Arrange
         TrailheadCalloutMock mock = new TrailheadCalloutMock();
@@ -112,6 +118,9 @@ private class GetTrailblazerInfoAsyncTest {
     }
 
     @IsTest
+    /**
+     * Tests encountering an error with superbadge data population.
+     */
     static void testSuperbadgeDataError() {
         // Arrange 
         TrailheadCalloutMock mock = new TrailheadCalloutMock();
@@ -134,7 +143,7 @@ private class GetTrailblazerInfoAsyncTest {
 
         // Act
         Test.startTest();
-        GetTrailblazerInfoAsync.populateTrailblazerSuperbadgeData(testTrailblazer, GetTrailblazerInfoAsync.getSuperbadgeData(testTrailblazer));
+        GetTrailblazerInfoAsync.getSuperbadgeData(testTrailblazer, GetTrailblazerInfoAsync.buildCalloutURL(testTrailblazer, GetTrailblazerInfoAsync.SUPERBADGES_PATH));
         Test.stopTest();
 
         // Assert
@@ -143,6 +152,9 @@ private class GetTrailblazerInfoAsyncTest {
     }
 
     @IsTest
+    /**
+     * Tests encountering an error with certification data population.
+     */
     static void testCertificationDataError() {
         // Arrange 
         TrailheadCalloutMock mock = new TrailheadCalloutMock();
@@ -165,11 +177,58 @@ private class GetTrailblazerInfoAsyncTest {
 
         // Act
         Test.startTest();
-        GetTrailblazerInfoAsync.populateTrailblazerCertificationData(testTrailblazer, GetTrailblazerInfoAsync.getCertificationData(testTrailblazer));
+        GetTrailblazerInfoAsync.getCertificationData(testTrailblazer, GetTrailblazerInfoAsync.buildCalloutURL(testTrailblazer, GetTrailblazerInfoAsync.CERTIFICATIONS_PATH));
         Test.stopTest();
 
         // Assert
         Trailblazer__c assertTrailblazer = [SELECT Certifications__c FROM Trailblazer__c WHERE Id = :testTrailblazer.Id];
         System.assertEquals(5, assertTrailblazer.Certifications__c, 'Certifications should not have been updated from a failed server callout.');
+    }
+
+    @IsTest
+    /**
+     * Tests an error with the Heroku application being down.
+     */
+    static void testGetTrailblazerInfoApplicationError() {
+        // Arrange
+        TrailheadCalloutMock mock = new TrailheadCalloutMock();
+        HttpResponse res = new HttpResponse();
+        res.setHeader('Content-Type', 'application/json');
+        res.setHeader('Location', 'trailheadURL.com');
+        res.setStatusCode(200);
+        res.setBody(TrailheadCalloutMock.getApplicationDownResponseData());
+        mock.addResponse(res);
+
+        Test.setMock(HttpCalloutMock.class, mock);
+
+        // Act 
+        Test.startTest();
+        System.enqueueJob(
+            new GetTrailblazerInfoAsync(
+                0, 
+                new List<Trailblazer__c>([
+                    SELECT Profile_Handle__c, Profile_Id__c 
+                    FROM Trailblazer__c
+                ])
+            )
+        );
+        Test.stopTest();
+
+        // Assert
+        List<Trailblazer__c> assertTrailblazers = [
+            SELECT Name, Badges__c, Trails__c, Superbadges__c, Certifications__c
+            FROM Trailblazer__c
+        ];
+
+        System.assertEquals(1, assertTrailblazers.size(),
+            'Should have created 1 Trailblazer during test set up and upserted that singular record.');
+        System.assertEquals(null, assertTrailblazers[0].Badges__c,
+            '0 badges should have been created from the profile counts data.');
+        System.assertEquals(null, assertTrailblazers[0].Superbadges__c,
+            '0 superbadges should have been created.');
+        System.assertEquals(null, assertTrailblazers[0].Certifications__c,
+            '0 certifications should have been created.');
+        System.assertEquals(null, assertTrailblazers[0].Trails__c,
+            '0 Trails__c should have been created.');
     }
 }

--- a/force-app/main/default/classes/ProfileCountData.cls
+++ b/force-app/main/default/classes/ProfileCountData.cls
@@ -5,6 +5,7 @@
 * A class to deserialize ProfileCounts data from the API into.
 */
 public class ProfileCountData {
+    public String error { get; set; }
     public List<value> value { get; set; }
 
     public class value {

--- a/force-app/main/default/classes/ProfileData.cls
+++ b/force-app/main/default/classes/ProfileData.cls
@@ -5,6 +5,7 @@
 * A class to deserialize Trailhead Profile data from the API into.
 */
 public class ProfileData {
+    public String error { get; set; }
     public String profilePhotoUrl { get; set; }
     public profileUser profileUser { get; set; }
 

--- a/force-app/main/default/classes/TrailheadCalloutMock.cls
+++ b/force-app/main/default/classes/TrailheadCalloutMock.cls
@@ -120,4 +120,8 @@ public class TrailheadCalloutMock implements HttpCalloutMock {
     public static String getUnsuccessfulResponseData() { 
         return '{"error":"No response from Trailhead"}';
     }
+
+    public static String getApplicationDownResponseData() { 
+        return 'Application error';
+    }
 }

--- a/force-app/main/default/classes/TrailheadCalloutMock.cls
+++ b/force-app/main/default/classes/TrailheadCalloutMock.cls
@@ -116,4 +116,8 @@ public class TrailheadCalloutMock implements HttpCalloutMock {
                 ']' +
             '}';
     }
+
+    public static String getUnsuccessfulResponseData() { 
+        return '{"error":"No response from Trailhead"}';
+    }
 }

--- a/force-app/main/default/classes/TrailheadLeaderboardAuraController.cls
+++ b/force-app/main/default/classes/TrailheadLeaderboardAuraController.cls
@@ -91,7 +91,12 @@ public without sharing class TrailheadLeaderboardAuraController {
 
         BadgeData data = (BadgeData) JSON.deserialize(res.getBody().replaceAll('__c', ''), BadgeData.class);
 
-        if (data.value != null && !data.value.isEmpty() && data.value[0].EarnedAwards != null && !data.value[0].EarnedAwards.isEmpty()) {
+        if (String.isBlank(data.error)
+            && data.value != null 
+            && !data.value.isEmpty() 
+            && data.value[0].EarnedAwards != null 
+            && !data.value[0].EarnedAwards.isEmpty()
+        ) {
             return data.value[0].EarnedAwards;
         } else {
             return null;
@@ -115,7 +120,12 @@ public without sharing class TrailheadLeaderboardAuraController {
 
         ProfileCountData data = (ProfileCountData) JSON.deserialize(res.getBody().replaceAll('__c', ''), ProfileCountData.class);
 
-        if (data.value != null && !data.value.isEmpty() && data.value[0].LearnedSkills != null && !data.value[0].LearnedSkills.isEmpty()) {
+        if (String.isBlank(data.error) 
+            && data.value != null 
+            && !data.value.isEmpty() 
+            && data.value[0].LearnedSkills != null 
+            && !data.value[0].LearnedSkills.isEmpty()
+        ) {
             return data.value[0].LearnedSkills;
         } else {
             return null;
@@ -139,7 +149,11 @@ public without sharing class TrailheadLeaderboardAuraController {
 
         CertificationData data = (CertificationData) JSON.deserialize(res.getBody().replaceAll('__c', ''), CertificationData.class);
 
-        if (data != null && data.certificationsList != null && !data.certificationsList.isEmpty()) {
+        if (String.isBlank(data.error) 
+            && data != null 
+            && data.certificationsList != null 
+            && !data.certificationsList.isEmpty()
+        ) {
             return data.certificationsList;
         } else {
             return null;

--- a/force-app/main/default/classes/TrailheadLeaderboardAuraController.cls
+++ b/force-app/main/default/classes/TrailheadLeaderboardAuraController.cls
@@ -48,17 +48,23 @@ public without sharing class TrailheadLeaderboardAuraController {
     @AuraEnabled
     public static String createTrailblazer(String userId) {
         Trailblazer__c newTrailblazer = new Trailblazer__c(Profile_Handle__c = userId.replace(' ', '').trim());
-        GetTrailblazerInfoAsync.populateTrailblazerProfileData(newTrailblazer, GetTrailblazerInfoAsync.getProfileData(newTrailblazer));
-        GetTrailblazerInfoAsync.populateTrailblazerProfileCountsData(newTrailblazer, GetTrailblazerInfoAsync.getProfileCountData(newTrailblazer));
-        GetTrailblazerInfoAsync.populateTrailblazerSuperbadgeData(newTrailblazer, GetTrailblazerInfoAsync.getSuperbadgeData(newTrailblazer));
-        GetTrailblazerInfoAsync.populateTrailblazerCertificationData(newTrailblazer, GetTrailblazerInfoAsync.getCertificationData(newTrailblazer));
+
+        for (String s : new Set<String>{
+            GetTrailblazerInfoAsync.getProfileCountsData(newTrailblazer, GetTrailblazerInfoAsync.buildCalloutURL(newTrailblazer, '')),
+            GetTrailblazerInfoAsync.getProfileData(newTrailblazer, GetTrailblazerInfoAsync.buildCalloutURL(newTrailblazer, GetTrailblazerInfoAsync.PROFILE_PATH)),
+            GetTrailblazerInfoAsync.getSuperbadgeData(newTrailblazer, GetTrailblazerInfoAsync.buildCalloutURL(newTrailblazer, GetTrailblazerInfoAsync.SUPERBADGES_PATH)),
+            GetTrailblazerInfoAsync.getCertificationData(newTrailblazer, GetTrailblazerInfoAsync.buildCalloutURL(newTrailblazer, GetTrailblazerInfoAsync.CERTIFICATIONS_PATH))
+        }) {
+            if (!s.equals(GetTrailblazerInfoAsync.SUCCESS)) {
+                return s;
+            }
+        }
 
         try {
             upsert newTrailblazer Profile_Handle__c;
             return 'success';
         } catch(Exception e) {
-            return 'Could not find a Trailhead profile for User Id/handle: ' + userId +
-                '. Please ensure your profile is set to public and you\'ve copied your Id correctly.';
+            return 'Error creating Trailblazer__c. Please try again.';
         }
     }
 

--- a/force-app/main/default/classes/TrailheadLeaderboardAuraControllerTest.cls
+++ b/force-app/main/default/classes/TrailheadLeaderboardAuraControllerTest.cls
@@ -91,6 +91,30 @@ private class TrailheadLeaderboardAuraControllerTest {
     }
 
     @IsTest
+    static void testCreateNewTrailblazerNoAPIResponse() {
+        // Arrange
+        TrailheadCalloutMock mock = new TrailheadCalloutMock();
+        HttpResponse res = new HttpResponse();
+        res.setHeader('Content-Type', 'application/json');
+        res.setHeader('Location', 'trailheadURL.com');
+        res.setStatusCode(200);
+        res.setBody(TrailheadCalloutMock.getUnsuccessfulResponseData());
+        mock.addResponse(res);
+
+        Test.setMock(HttpCalloutMock.class, mock);
+        Test.setCurrentPage(Page.trailheadLeaderboard);
+
+        // Act
+        Test.startTest();
+        String resultString = TrailheadLeaderboardAuraController.createTrailblazer('someId');
+        Test.stopTest();
+
+        // Assert
+        Trailblazer__c assertTrailblazer = [SELECT Badges__c FROM Trailblazer__c WHERE Profile_Handle__c = 'someId'];
+        System.assertEquals(null, assertTrailblazer.Badges__c, 'Badges shouldn\'t have been updates as there was an error response from the API.');
+    }
+
+    @IsTest
     static void testGetSkillData() {
         // Arrange
         TrailheadCalloutMock mock = new TrailheadCalloutMock();
@@ -181,5 +205,28 @@ private class TrailheadLeaderboardAuraControllerTest {
             System.assertNotEquals(null, award.LearningUrl);
             System.assertNotEquals(null, award.AwardType);
         }
+    }
+
+    @IsTest
+    static void testGetBadgeDataNoAPIResponse() {
+        // Arrange
+        TrailheadCalloutMock mock = new TrailheadCalloutMock();
+        HttpResponse res = new HttpResponse();
+        res.setHeader('Content-Type', 'application/json');
+        res.setHeader('Location', 'trailheadURL.com');
+        res.setStatusCode(200);
+        res.setBody(TrailheadCalloutMock.getUnsuccessfulResponseData());
+        mock.addResponse(res);
+
+        Test.setMock(HttpCalloutMock.class, mock);
+        Test.setCurrentPage(Page.trailheadLeaderboard);
+
+        // Act
+        Test.startTest();
+        List<BadgeData.EarnedAwards> badges = TrailheadLeaderboardAuraController.getBadgeData('someId', 'all', '0');
+        Test.stopTest();
+
+        // Assert
+        System.assertEquals(null, badges, 'No badges should have been returned as the API failed to respond with data.');
     }
 }

--- a/force-app/main/default/classes/TrailheadLeaderboardAuraControllerTest.cls
+++ b/force-app/main/default/classes/TrailheadLeaderboardAuraControllerTest.cls
@@ -91,7 +91,7 @@ private class TrailheadLeaderboardAuraControllerTest {
     }
 
     @IsTest
-    static void testCreateNewTrailblazerNoAPIResponse() {
+    static void testCreateNewTrailblazerWithError() {
         // Arrange
         TrailheadCalloutMock mock = new TrailheadCalloutMock();
         HttpResponse res = new HttpResponse();
@@ -110,8 +110,13 @@ private class TrailheadLeaderboardAuraControllerTest {
         Test.stopTest();
 
         // Assert
-        Trailblazer__c assertTrailblazer = [SELECT Badges__c FROM Trailblazer__c WHERE Profile_Handle__c = 'someId'];
-        System.assertEquals(null, assertTrailblazer.Badges__c, 'Badges shouldn\'t have been updates as there was an error response from the API.');
+        System.assertEquals(0, [SELECT Id FROM Trailblazer__c WHERE Profile_Handle__c = :'someId'].size(), 
+            'Test Trailblazer should not have been created.');
+        System.assertNotEquals('success', resultString);
+        System.assertEquals(2,
+            TrailheadLeaderboardAuraController.populateTrailblazers('', null).size(),
+            'Only the two Trailblazers should exist, \'someId\' should not have been created.'
+        );
     }
 
     @IsTest

--- a/force-app/main/default/lwc/alertMessage/alertMessage.html
+++ b/force-app/main/default/lwc/alertMessage/alertMessage.html
@@ -1,11 +1,11 @@
 <template>
     <div if:false={dontShow}>
-        <div class={alertClass} role="alert">
+        <div class={alertClass} role="alert" style="border-radius:.25rem;">
             <span class="slds-assistive-text">{assistText}</span>
             <span if:true={showIcon} class="slds-icon_container slds-m-right_x-small" title="Description of icon when needed">
                 <lightning-icon icon-name={iconName} size="x-small" alternative-text={assistText} variant="inverse"></lightning-icon>
             </span>
-            <h2 style="width:80%;">{message}</h2>
+            <h2>{message}</h2>
             <div class="slds-notify__close">
                 <button class="slds-button slds-button_icon slds-button_icon-small slds-button_icon-inverse" title="Close" onclick={hideMessage}>
                     <lightning-icon icon-name="utility:close" size="x-small" alternative-text="close" variant="inverse"></lightning-icon>

--- a/force-app/main/default/lwc/leaderboardBadges/leaderboardBadges.js
+++ b/force-app/main/default/lwc/leaderboardBadges/leaderboardBadges.js
@@ -13,11 +13,11 @@ export default class LeaderboardBadges extends LightningElement {
     offset = OFFSET_STEP;
 
     badgeTypeOptions = [
-        { "label": "All", "value": "all" },
-        { "label": "Superbadges", "value": "superbadge" },
-        { "label": "Modules", "value": "module" },
-        { "label": "Projects", "value": "project" },
-        { "label": "Event/Community", "value": "event" }
+        { label: "All", value: "all" },
+        { label: "Superbadges", value: "superbadge" },
+        { label: "Modules", value: "module" },
+        { label: "Projects", value: "project" },
+        { label: "Event/Community", value: "event" }
     ];
 
     @api
@@ -89,8 +89,6 @@ export default class LeaderboardBadges extends LightningElement {
     }
 
     get showMore() {
-        console.log(this.badges.length);
-        console.log(this.trailblazer.Badges__c);
         return this.badges && this.badges.length > 29 && this.badges.length !== this.trailblazer.Badges__c && !this.noMoreBadges;
     }
 

--- a/force-app/main/default/lwc/leaderboardNewTrailblazerModal/leaderboardNewTrailblazerModal.html
+++ b/force-app/main/default/lwc/leaderboardNewTrailblazerModal/leaderboardNewTrailblazerModal.html
@@ -20,7 +20,7 @@
                 </header>
                 <div class="slds-modal__content slds-p-around_medium modal-body" id="newTrailblazerModalContent">
                     <div if:true={error}>
-                        <c-alert-message type="error" message={error} textured></c-alert-message>
+                        <c-alert-message type="error" message={error} show-icon textured></c-alert-message>
                     </div>
                     <lightning-input
                             label="Trailhead Handle"


### PR DESCRIPTION
# Changes

- Apex callouts now support a response `error` message when API fails to return any data. See [#9](https://github.com/meruff/go-trailhead-leaderboard-api/pull/9) on the API repo.
- Removed redundant creation of `new Trailblazer__()` record when upserting, just using existing user now.
- Removed resetting of Certifications and Superbadges to `0` when API returns no data.
- Removed unnecessary `console.log` statements and quotes around options objects in `leaderboardBadges.js`.
- Updated how errors are displayed on the front end. 
- Styling changes to the alert notification.
- Update Apex tests.